### PR TITLE
Added ability to refernce metadata fields from within the markdown file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ Metadata can also be provided on the command-line with the `-d|--define` option.
 
     restdown --define mediaroot=/ index.restdown
 
+## Using Metadata Fields
+
+You can also access the values of the metadata fields you set in your markdown as follows:
+
+    ---
+    author: John Doe
+    created: 3rd September 2013
+    ---
+
+    The author of this document is #{author}. It was created on #{created}.
+
+
 
 # JSON API Summary
 

--- a/bin/restdown
+++ b/bin/restdown
@@ -269,6 +269,9 @@ def restdown(metadata, markdown, brand_dir=None, doc_dir=None):
     @returns {str, dict} The HTML document (full page) and a dict giving
         data about the API: version, endpoints.
     """
+    for key in metadata:
+        markdown = re.sub(r"#{" + key + "}", metadata.get(key), markdown)
+
     doc_markdown_opts = copy.deepcopy(markdown_opts)
     for extra in metadata.get("markdown2extras", []):
         doc_markdown_opts["extras"][extra] = True


### PR DESCRIPTION
Added syntax for accessing the metadata fields within the markdown file. You can now access them using the following syntax: 

```
#{metadata_field_name}
```
