### PR TITLE
Fix #current styling for elements with same name

### DIFF
--- a/brand/ohthejoy/footer.html.in
+++ b/brand/ohthejoy/footer.html.in
@@ -46,7 +46,7 @@ $(function() {
             $("#sidebar li>div").removeClass("current");
             currSectionIdx = sectionIdx;
             if (currSectionIdx >= 0) {
-                var heading = $(sections[currSectionIdx]).text();
+                var heading = $(sections[currSectionIdx]).attr('id');
                 var possibleAnchors = [
                     slugify(heading), // h1 or non-method h2
                     heading.replace(/ /g, '-'), // h2 method, just name or just endpoint


### PR DESCRIPTION
Small issue. We use ohthejoy and structure sections like something like this:
```
# <Method>:<Route>
## Request
```
So any time scrolling is on a `Request` section, the first section gets the `current` style. Taking the id (e.g., `request-2`) instead of the text solves this problem.