### PR TITLE
Add workarounds so we can run with python3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 # restdown Changelog
 
+## restdown 1.4.2 (not released yet)
+
 ## restdown 1.4.1 (not yet released)
 
-(nothing yet)
-
+- Allow us to run in environments where python3.x is the default python
 
 ## restdown 1.4.0
 

--- a/bin/restdown
+++ b/bin/restdown
@@ -30,9 +30,22 @@ import logging
 import json
 import copy
 import optparse
-from StringIO import StringIO
+
+if sys.version_info[0] <= 2:
+    from StringI import StringIO
+    from urllib import quote_plus as urlquote
+
+    class RestdownError(StandardError):
+        pass
+
+elif sys.version_info[0] >= 3:
+    from io import StringIO
+    from urllib.parse import quote_plus as urlquote
+
+    class RestdownError(Exception):
+        pass
+
 import csv
-from urllib import quote_plus as urlquote
 
 _saved_path = sys.path[:]
 sys.path.insert(0, join(dirname(dirname(abspath(realpath(__file__)))), "externals", "lib")) # dev layout
@@ -56,11 +69,6 @@ markdown_opts = {
         "markdown-in-html": True,
     }
 }
-
-
-class RestdownError(StandardError):
-    pass
-
 
 
 #---- restdown processor
@@ -229,7 +237,11 @@ def restdown_path(path, brand_dir=None, copy_brand_media_to=None, defines=None,
             f = StringIO(metadata[key])
             reader = csv.reader(f)
             try:
-                row = [cell.strip() for cell in reader.next()]
+                row = None
+                if sys.version_info[0] >= 3:
+                    row = [cell.strip() for cell in reader.__next__()]
+                else:
+                    row = [cell.strip() for cell in reader.next()]
             except StopIteration:
                 row = []
             metadata[key] = row
@@ -445,7 +457,11 @@ class _NoReflowFormatter(optparse.IndentedHelpFormatter):
 try:
     from thread import get_ident as _get_ident
 except ImportError:
-    from dummy_thread import get_ident as _get_ident
+    try:
+        from dummy_thread import get_ident as _get_ident
+    except ImportError:
+        from _dummy_thread import get_ident as _get_ident
+
 
 try:
     from _abcoll import KeysView, ValuesView, ItemsView

--- a/bin/restdown
+++ b/bin/restdown
@@ -32,7 +32,7 @@ import copy
 import optparse
 
 if sys.version_info[0] <= 2:
-    from StringI import StringIO
+    from StringIO import StringIO
     from urllib import quote_plus as urlquote
 
     class RestdownError(StandardError):


### PR DESCRIPTION
To test this, I bumped a branch of manta-muskie to these bits, https://github.com/joyent/manta-muskie/tree/ook, which now builds cleanly:

```
timf@jenkins-agent-x86_64-19.4.0 (ook) git log -1
commit ba532479271e3a6c947c86f7cd79c5304ab677a1 (HEAD -> ook, origin/ook)
Author: Tim Foster <tim.foster@joyent.com>
Date:   Mon Mar 9 17:48:49 2020 +0000

    temporary branch to test timf's restdown patch
timf@jenkins-agent-x86_64-19.4.0 (ook) make docs
mkdir -p build/docs/public
python deps/restdown/bin/restdown --brand-dir=docs/bluejoy -m build/docs/public docs/index.md
restdown: info: wrote docs/index.html
restdown: info: wrote docs/index.json
restdown: info: cp build/docs/public/media/img/arrow.svg
restdown: info: cp build/docs/public/media/img/how-it-works-2.svg
restdown: info: cp build/docs/public/media/img/favicon.ico
restdown: info: cp build/docs/public/media/img/heatmap.png
restdown: info: cp build/docs/public/media/img/logo.svg
restdown: info: cp build/docs/public/media/img/logo.png
restdown: info: cp build/docs/public/media/img/how-it-works-1.svg
restdown: info: cp build/docs/public/media/css/restdown.css
mkdir -p build/docs/public
cp docs/index.html build/docs/public/index.html
mkdir -p build/docs/public
cp docs/index.json build/docs/public/index.json
timf@jenkins-agent-x86_64-19.4.0 (ook) cd deps/restdown/
timf@jenkins-agent-x86_64-19.4.0 ((HEAD detached from 92f2b5d)) git log -1
commit ca122fd560dba9eb427213c10e53bd691080d34f (HEAD, origin/fix-python3)
Author: Tim Foster <tim.foster@joyent.com>
Date:   Mon Mar 9 17:44:02 2020 +0000

    Add workarounds so we can run with python3
timf@jenkins-agent-x86_64-19.4.0 ((HEAD detached from 92f2b5d)) git remote -v
origin  https://github.com/timfoster/restdown (fetch)
origin  https://github.com/timfoster/restdown (push)
timf@jenkins-agent-x86_64-19.4.0 ((HEAD detached from 92f2b5d)) python --version
Python 3.7.5
```

The index.html file above is at http://us-east.manta.joyent.com/timf/public/py3-restdown-example-index.html, but I've not uploaded the various other media/json resources it needs to render completely properly.